### PR TITLE
Fix form and map section validation errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
       <div class="form-container">
         <h1 class="title">IP Address Tracker</h1>
 
-        <form class="form" action="">
+        <form class="form">
           <input
             type="text"
             placeholder="Search for any IP address or domain"
@@ -76,9 +76,9 @@
       </div>
     </section>
 
-    <section class="map-container">
+    <div class="map-container">
       <div id="mapID"></div>
-    </section>
+    </div>
 
     <section class="error">
       <h1>INVALID IP OR DOMAIN</h1>


### PR DESCRIPTION
1) Bad value for attribute action on element form: Must be non-empty.

```html  <form class="form" action=""> ```

2) Section lacks heading. Consider using h2-h6 elements to add identifying headings to all sections
```html <section class="map-container"> ```